### PR TITLE
`lent` for some return types and `unsafeError` func

### DIFF
--- a/results.nim
+++ b/results.nim
@@ -491,7 +491,7 @@ template `[]`*[T, E](self: var Result[T, E]): var T =
   mixin get
   self.get()
 
-func expect*[T: not void, E](self: Result[T, E], m: string): lent T =
+func expect*[T: not void, E](self: Result[T, E], m: string): lent T {.inline.} =
   ## Return value of Result, or raise a `Defect` with the given message - use
   ## this helper to extract the value when an error is not expected, for example
   ## because the program logic dictates that the operation should never fail
@@ -508,7 +508,7 @@ func expect*[T: not void, E](self: Result[T, E], m: string): lent T =
       raiseResultDefect(m)
   self.v
 
-func expect*[T: not void, E](self: var Result[T, E], m: string): var T =
+func expect*[T: not void, E](self: var Result[T, E], m: string): var T {.inline.} =
   if not self.o:
     when E isnot void:
       raiseResultDefect(m, self.e)

--- a/results.nim
+++ b/results.nim
@@ -444,21 +444,21 @@ func `==`*[E0, E1](lhs: Result[void, E0], rhs: Result[void, E1]): bool {.inline.
   else:
     lhs.e == rhs.e
 
-func get*[T: not void, E](self: Result[T, E]): T {.inline.} =
+func get*[T: not void, E](self: Result[T, E]): lent T {.inline.} =
   ## Fetch value of result if set, or raise Defect
   ## Exception bridge mode: raise given Exception instead
   ## See also: Option.get
   assertOk(self)
   self.v
 
-func tryGet*[T: not void, E](self: Result[T, E]): T {.inline.} =
+func tryGet*[T: not void, E](self: Result[T, E]): lent T {.inline.} =
   ## Fetch value of result if set, or raise
   ## When E is an Exception, raise that exception - otherwise, raise a ResultError[E]
   mixin raiseResultError
   if not self.o: self.raiseResultError()
   self.v
 
-func get*[T, E](self: Result[T, E], otherwise: T): T {.inline.} =
+func get*[T, E](self: Result[T, E], otherwise: T): lent T {.inline.} =
   ## Fetch value of result if set, or return the value `otherwise`
   ## See `valueOr` for a template version that avoids evaluating `otherwise`
   ## unless necessary
@@ -484,14 +484,14 @@ template `[]`*[T, E](self: var Result[T, E]): var T =
   mixin get
   self.get()
 
-template unsafeGet*[T, E](self: Result[T, E]): T =
+template unsafeGet*[T, E](self: Result[T, E]): lent T =
   ## Fetch value of result if set, undefined behavior if unset
   ## See also: Option.unsafeGet
   assert self.o
 
   self.v
 
-func expect*[T: not void, E](self: Result[T, E], m: string): T =
+func expect*[T: not void, E](self: Result[T, E], m: string): lent T =
   ## Return value of Result, or raise a `Defect` with the given message - use
   ## this helper to extract the value when an error is not expected, for example
   ## because the program logic dictates that the operation should never fail
@@ -521,7 +521,7 @@ func `$`*(self: Result): string =
   if self.o: "Ok(" & $self.v & ")"
   else: "Err(" & $self.e & ")"
 
-func error*[T, E](self: Result[T, E]): E =
+func error*[T, E](self: Result[T, E]): lent E =
   ## Fetch error of result if set, or raise Defect
   if self.o:
     when T is not void:


### PR DESCRIPTION
- New `unsafeError` like `unsafeGet`
- `lent` for `get`/`tryGet`/`unsafeGet`/`expect`/`error`/`unsafeError`  like in [std/options](https://github.com/nim-lang/Nim/blob/e70044fb280909a2da15dc763c9c549a4857632f/lib/pure/options.nim#L170)