### PR TITLE
`Result` refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
           - os: linux
             cpu: amd64
             TEST_LANG: cpp
-        branch: [version-1-2, version-1-4]
+        branch: [version-1-2, version-1-4, version-1-6]
         include:
           - target:
               os: linux

--- a/result.nimble
+++ b/result.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.0"
+version       = "0.3.0"
 author        = "Jacek Sieka"
 description   = "Friendly, exception-free value-or-error returns, similar to Option[T]"
 license       = "MIT"


### PR DESCRIPTION
* add full support for `Result[T, void]` (aka `Opt[T]` aka `Option[T]`)
* expand tests
* add `flatten`, `filter` of `Option` fame
* add `tryError` that raises a regular exception when result holds a
value
* fix `$` to print `ok`/`err` in lower-case, like the functions that
created the result
* add `orErr` that collapses all errors to a single value of a
potentially different type - useful when translating errors between
layers
* `capture` should work with `CatchableError`
* remove `Defect`-dependent tests