### PR TITLE
case-wrap raise* helpers for strictCaseObjects

### DIFF
--- a/results.nim
+++ b/results.nim
@@ -403,29 +403,39 @@ func raiseResultOk[T, E](self: Result[T, E]) {.noreturn, noinline.} =
   when T is void:
     raise (ref ResultError[void])(msg: "Trying to access error with value")
   else:
-    raise (ref ResultError[T])(
-      msg: "Trying to access error with value", error: self.vResultPrivate
-    )
+    case self.oResultPrivate
+    of true:
+      raise (ref ResultError[T])(
+        msg: "Trying to access error with value", error: self.vResultPrivate
+      )
+    of false:
+      raise (ref ResultError[void])(msg: "Trying to access error with value")
 
 func raiseResultError[T, E](self: Result[T, E]) {.noreturn, noinline.} =
   # noinline because raising should take as little space as possible at call
   # site
   mixin toException
 
-  when E is ref Exception:
-    if self.eResultPrivate.isNil: # for example Result.default()!
-      raise (ref ResultError[void])(msg: "Trying to access value with err (nil)")
-    raise self.eResultPrivate
-  elif E is void:
+  when E is void:
     raise (ref ResultError[void])(msg: "Trying to access value with err")
-  elif compiles(toException(self.eResultPrivate)):
-    raise toException(self.eResultPrivate)
-  elif compiles($self.eResultPrivate):
-    raise (ref ResultError[E])(error: self.eResultPrivate, msg: $self.eResultPrivate)
   else:
-    raise (ref ResultError[E])(
-      msg: "Trying to access value with err", error: self.eResultPrivate
-    )
+    case self.oResultPrivate
+    of false:
+      when E is ref Exception:
+        if self.eResultPrivate.isNil: # for example Result.default()!
+          raise (ref ResultError[void])(msg: "Trying to access value with err (nil)")
+        raise self.eResultPrivate
+      elif compiles(toException(self.eResultPrivate)):
+        raise toException(self.eResultPrivate)
+      elif compiles($self.eResultPrivate):
+        raise
+          (ref ResultError[E])(error: self.eResultPrivate, msg: $self.eResultPrivate)
+      else:
+        raise (ref ResultError[E])(
+          msg: "Trying to access value with err", error: self.eResultPrivate
+        )
+    of true:
+      raise (ref ResultError[void])(msg: "Trying to access value with err")
 
 func raiseResultDefect(m: string, v: auto) {.noreturn, noinline.} =
   mixin `$`

--- a/results.nim
+++ b/results.nim
@@ -397,35 +397,32 @@ else:
   template maybeLent(T: untyped): untyped =
     T
 
-func raiseResultOk[T, E](self: Result[T, E]) {.noreturn, noinline.} =
+func raiseResultOk() {.noreturn, noinline.} =
   # noinline because raising should take as little space as possible at call
   # site
-  when T is void:
-    raise (ref ResultError[void])(msg: "Trying to access error with value")
-  else:
-    raise (ref ResultError[T])(
-      msg: "Trying to access error with value", error: self.vResultPrivate
-    )
+  raise (ref ResultError[void])(msg: "Trying to access error with value")
 
-func raiseResultError[T, E](self: Result[T, E]) {.noreturn, noinline.} =
+func raiseResultOk[T](v: T) {.noreturn, noinline.} =
+  raise (ref ResultError[T])(msg: "Trying to access error with value", error: v)
+
+func raiseResultError() {.noreturn, noinline.} =
   # noinline because raising should take as little space as possible at call
   # site
+  raise (ref ResultError[void])(msg: "Trying to access value with err")
+
+func raiseResultError[E](e: E) {.noreturn, noinline.} =
   mixin toException
 
   when E is ref Exception:
-    if self.eResultPrivate.isNil: # for example Result.default()!
+    if e.isNil: # for example Result.default()!
       raise (ref ResultError[void])(msg: "Trying to access value with err (nil)")
-    raise self.eResultPrivate
-  elif E is void:
-    raise (ref ResultError[void])(msg: "Trying to access value with err")
-  elif compiles(toException(self.eResultPrivate)):
-    raise toException(self.eResultPrivate)
-  elif compiles($self.eResultPrivate):
-    raise (ref ResultError[E])(error: self.eResultPrivate, msg: $self.eResultPrivate)
+    raise e
+  elif compiles(toException(e)):
+    raise toException(e)
+  elif compiles($e):
+    raise (ref ResultError[E])(error: e, msg: $e)
   else:
-    raise (ref ResultError[E])(
-      msg: "Trying to access value with err", error: self.eResultPrivate
-    )
+    raise (ref ResultError[E])(msg: "Trying to access value with err", error: e)
 
 func raiseResultDefect(m: string, v: auto) {.noreturn, noinline.} =
   mixin `$`
@@ -917,7 +914,10 @@ func tryValue*[E](self: Result[void, E]) {.inline.} =
   mixin raiseResultError
   case self.oResultPrivate
   of false:
-    self.raiseResultError()
+    when E isnot void:
+      raiseResultError(self.eResultPrivate)
+    else:
+      raiseResultError()
   of true:
     discard
 
@@ -927,7 +927,10 @@ func tryValue*[T: not void, E](self: Result[T, E]): maybeLent T {.inline.} =
   mixin raiseResultError
   case self.oResultPrivate
   of false:
-    self.raiseResultError()
+    when E isnot void:
+      raiseResultError(self.eResultPrivate)
+    else:
+      raiseResultError()
   of true:
     # TODO https://github.com/nim-lang/Nim/issues/22216
     result = self.vResultPrivate
@@ -1026,7 +1029,10 @@ func tryError*[T](self: Result[T, void]) {.inline.} =
   mixin raiseResultOk
   case self.oResultPrivate
   of true:
-    self.raiseResultOk()
+    when T isnot void:
+      raiseResultOk(self.vResultPrivate)
+    else:
+      raiseResultOk()
   of false:
     discard
 
@@ -1036,7 +1042,10 @@ func tryError*[T; E: not void](self: Result[T, E]): maybeLent E {.inline.} =
   mixin raiseResultOk
   case self.oResultPrivate
   of true:
-    self.raiseResultOk()
+    when T isnot void:
+      raiseResultOk(self.vResultPrivate)
+    else:
+      raiseResultOk()
   of false:
     # TODO https://github.com/nim-lang/Nim/issues/22216
     result = self.eResultPrivate


### PR DESCRIPTION
raiseResultOk and raiseResultError read self.vResultPrivate / self.eResultPrivate without a discriminating case so any module compiled with `{.experimental: "strictCaseObjects".}` fails at generic instantiation of tryValue / tryError.
 
Change the helpers to take the payload they raise directly, raiseResultOk[T](v: T) and raiseResultError[E](e: E), with no-argument overloads for the void specialisations. The tryValue / tryError call sites already case on oResultPrivate so they now read the field inside the proving of branch and pass it in. This leaves no variant-field access in the helpers at all, needs no cast(uncheckedAssign), and drops the unused type parameter so each helper instantiates per E (or per T) instead of per (T, E) pair.
 
Taking the payload as a parameter rather than case-wrapping the helper bodies also keeps compiles($e)/compiles(toException(e)) meaningful under strict consumers

No behavioural change; test_results and test_results2 pass under both default gc and --mm:refc.