### PR TITLE
case-wrap `==` operators for strictCaseObjects

### DIFF
--- a/results.nim
+++ b/results.nim
@@ -831,34 +831,45 @@ template capture*[E: Exception](T: type, someExceptionExpr: ref E): Result[T, re
 func `==`*[T0: not void, E0: not void, T1: not void, E1: not void](
     lhs: Result[T0, E0], rhs: Result[T1, E1]
 ): bool {.inline.} =
-  if lhs.oResultPrivate != rhs.oResultPrivate:
-    false
-  else:
-    case lhs.oResultPrivate # and rhs.oResultPrivate implied
+  case lhs.oResultPrivate
+  of true:
+    case rhs.oResultPrivate
     of true:
       lhs.vResultPrivate == rhs.vResultPrivate
+    of false:
+      false
+  of false:
+    case rhs.oResultPrivate
+    of true:
+      false
     of false:
       lhs.eResultPrivate == rhs.eResultPrivate
 
 func `==`*[E0, E1](lhs: Result[void, E0], rhs: Result[void, E1]): bool {.inline.} =
-  if lhs.oResultPrivate != rhs.oResultPrivate:
-    false
-  else:
-    case lhs.oResultPrivate # and rhs.oResultPrivate implied
+  case lhs.oResultPrivate
+  of true:
+    case rhs.oResultPrivate
+    of true: true
+    of false: false
+  of false:
+    case rhs.oResultPrivate
     of true:
-      true
+      false
     of false:
       lhs.eResultPrivate == rhs.eResultPrivate
 
 func `==`*[T0, T1](lhs: Result[T0, void], rhs: Result[T1, void]): bool {.inline.} =
-  if lhs.oResultPrivate != rhs.oResultPrivate:
-    false
-  else:
-    case lhs.oResultPrivate # and rhs.oResultPrivate implied
+  case lhs.oResultPrivate
+  of true:
+    case rhs.oResultPrivate
     of true:
       lhs.vResultPrivate == rhs.vResultPrivate
     of false:
-      true
+      false
+  of false:
+    case rhs.oResultPrivate
+    of true: false
+    of false: true
 
 func value*[E](self: Result[void, E]) {.inline.} =
   ## Fetch value of result if set, or raise Defect

--- a/results.nim
+++ b/results.nim
@@ -833,34 +833,41 @@ template capture*[E: Exception](T: type, someExceptionExpr: ref E): Result[T, re
 func `==`*[T0: not void, E0: not void, T1: not void, E1: not void](
     lhs: Result[T0, E0], rhs: Result[T1, E1]
 ): bool {.inline.} =
-  if lhs.oResultPrivate != rhs.oResultPrivate:
-    false
-  else:
-    case lhs.oResultPrivate # and rhs.oResultPrivate implied
+  case lhs.oResultPrivate
+  of true:
+    case rhs.oResultPrivate
     of true:
       lhs.vResultPrivate == rhs.vResultPrivate
+    of false:
+      false
+  of false:
+    case rhs.oResultPrivate
+    of true:
+      false
     of false:
       lhs.eResultPrivate == rhs.eResultPrivate
 
 func `==`*[E0, E1](lhs: Result[void, E0], rhs: Result[void, E1]): bool {.inline.} =
-  if lhs.oResultPrivate != rhs.oResultPrivate:
-    false
-  else:
-    case lhs.oResultPrivate # and rhs.oResultPrivate implied
+  case lhs.oResultPrivate
+  of true:
+    rhs.oResultPrivate
+  of false:
+    case rhs.oResultPrivate
     of true:
-      true
+      false
     of false:
       lhs.eResultPrivate == rhs.eResultPrivate
 
 func `==`*[T0, T1](lhs: Result[T0, void], rhs: Result[T1, void]): bool {.inline.} =
-  if lhs.oResultPrivate != rhs.oResultPrivate:
-    false
-  else:
-    case lhs.oResultPrivate # and rhs.oResultPrivate implied
+  case lhs.oResultPrivate
+  of true:
+    case rhs.oResultPrivate
     of true:
       lhs.vResultPrivate == rhs.vResultPrivate
     of false:
-      true
+      false
+  of false:
+    not rhs.oResultPrivate
 
 func value*[E](self: Result[void, E]) {.inline.} =
   ## Fetch value of result if set, or raise Defect


### PR DESCRIPTION
The three Result \`==\` overloads used \`if lhs.o != rhs.o: false; else: case lhs.o of true: lhs.v == rhs.v of false: lhs.e == rhs.e\`. Under strictCaseObjects, the \`rhs.v\` / \`rhs.e\` reads are rejected because only \`lhs.o\` was discriminated; the implicit equality between lhs.o and rhs.o (from the outer if) is not tracked across branches by strict's flow analysis.

Restructure each overload so every variant-field read sits inside a proving of branch on the operand it belongs to. Arms that touch no variant field use the discriminator value directly. Identical runtime behaviour.

Three overloads rewritten:
  * \`Result[T0, E0] == Result[T1, E1]\` (non-void T, non-void E)
  * \`Result[void, E0] == Result[void, E1]\`
  * \`Result[T0, void] == Result[T1, void]\`