### PR TITLE
add: toOpt

### DIFF
--- a/results.nim
+++ b/results.nim
@@ -1638,3 +1638,10 @@ func contains*(self: Opt, v: auto): bool =
     self.vResultPrivate == v
   of false:
     false
+
+func toOpt*[T](v: Opt[T] | T): Opt[T] =
+  ## Converts union type of `T` or `Opt[T]` into `Opt[T]`.
+  when v is T:
+    Opt.some(v)
+  else:
+    v


### PR DESCRIPTION
useful for following pattern:

```nim
proc new*(
    T: type LPProtocol,
    codecs: seq[string],
    handler: LPProtoHandler,
    maxIncomingStreamsTotal: Opt[int] | int = Opt.none(int),
    maxIncomingStreamsPerPeer: Opt[int] | int = 10,
    maxOutgoingStreamsTotal: Opt[int] | int = Opt.none(int),
    maxOutgoingStreamsPerPeer: Opt[int] | int = 10,
): T =
  T(
    codecs: codecs,
    handlerImpl: handler,
    maxIncomingStreamsTotal: toOpt(maxIncomingStreamsTotal),
    maxIncomingStreamsPerPeer: toOpt(maxIncomingStreamsPerPeer),
    maxOutgoingStreamsTotal: toOpt(maxOutgoingStreamsTotal),
    maxOutgoingStreamsPerPeer: toOpt(maxOutgoingStreamsPerPeer),
    streamBudget: StreamBudgetState(
      perPeerIncoming: initCountTable[PeerId](),
      perPeerOutgoing: initCountTable[PeerId](),
    ),
  )
  ``` 