### PR TITLE
prefer `typed` template arguments for ok/err

### DIFF
--- a/results.nim
+++ b/results.nim
@@ -448,7 +448,7 @@ template withAssertOk(self: Result, body: untyped): untyped =
   of true:
     body
 
-template ok*[T: not void, E](R: type Result[T, E], x: untyped): R =
+template ok*[T: not void, E](R: type Result[T, E], x: typed): R =
   ## Initialize a result with a success and value
   ## Example: `Result[int, string].ok(42)`
   R(oResultPrivate: true, vResultPrivate: x)
@@ -458,7 +458,7 @@ template ok*[E](R: type Result[void, E]): R =
   ## Example: `Result[void, string].ok()`
   R(oResultPrivate: true)
 
-template ok*[T: not void, E](self: var Result[T, E], x: untyped) =
+template ok*[T: not void, E](self: var Result[T, E], x: typed) =
   ## Set the result to success and update value
   ## Example: `result.ok(42)`
   self = ok(type self, x)
@@ -468,7 +468,7 @@ template ok*[E](self: var Result[void, E]) =
   ## Example: `result.ok()`
   self = (type self).ok()
 
-template err*[T; E: not void](R: type Result[T, E], x: untyped): R =
+template err*[T; E: not void](R: type Result[T, E], x: typed): R =
   ## Initialize the result to an error
   ## Example: `Result[int, string].err("uh-oh")`
   R(oResultPrivate: false, eResultPrivate: x)
@@ -484,7 +484,7 @@ template err*[T](R: type Result[T, void]): R =
   ## Example: `Result[int, void].err()`
   R(oResultPrivate: false)
 
-template err*[T; E: not void](self: var Result[T, E], x: untyped) =
+template err*[T; E: not void](self: var Result[T, E], x: typed) =
   ## Set the result as an error
   ## Example: `result.err("uh-oh")`
   self = err(type self, x)
@@ -498,13 +498,13 @@ template err*[T](self: var Result[T, void]) =
   ## Example: `result.err()`
   self = err(type self)
 
-template ok*(v: auto): auto =
+template ok*(v: typed): auto =
   ok(typeof(result), v)
 
 template ok*(): auto =
   ok(typeof(result))
 
-template err*(v: auto): auto =
+template err*(v: typed): auto =
   err(typeof(result), v)
 
 template err*(): auto =

--- a/tests/test_results.nim
+++ b/tests/test_results.nim
@@ -384,39 +384,39 @@ block: # Result[void, E]
 
   # Mapping
   doAssert vOk
-  .map(
-    proc(): int =
-      42
-  )
-  .get() == 42
+    .map(
+      proc(): int =
+        42
+    )
+    .get() == 42
 
   vOk
-  .map(
-    proc() =
-      discard
-  )
-  .get()
+    .map(
+      proc() =
+        discard
+    )
+    .get()
 
   vOk
-  .mapErr(
-    proc(x: int): int =
-      10
-  )
-  .get()
+    .mapErr(
+      proc(x: int): int =
+        10
+    )
+    .get()
 
   vOk
-  .mapErr(
-    proc(x: int) =
-      discard
-  )
-  .get()
+    .mapErr(
+      proc(x: int) =
+        discard
+    )
+    .get()
 
   doAssert vErr
-  .mapErr(
-    proc(x: int): int =
-      10
-  )
-  .error() == 10
+    .mapErr(
+      proc(x: int): int =
+        10
+    )
+    .error() == 10
 
   # string conversion
   doAssert $vOk == "ok()"
@@ -497,38 +497,38 @@ block: # Result[T, void] aka `Opt`
 
   # Mapping
   doAssert oOk
-  .map(
-    proc(x: int): string =
-      $x
-  )
-  .get() == $oOk.get()
+    .map(
+      proc(x: int): string =
+        $x
+    )
+    .get() == $oOk.get()
 
   oOk
-  .map(
-    proc(x: int) =
-      discard
-  )
-  .get()
+    .map(
+      proc(x: int) =
+        discard
+    )
+    .get()
 
   doAssert oOk
-  .mapErr(
-    proc(): int =
-      10
-  )
-  .get() == oOk.get()
+    .mapErr(
+      proc(): int =
+        10
+    )
+    .get() == oOk.get()
   doAssert oOk
-  .mapErr(
-    proc() =
-      discard
-  )
-  .get() == oOk.get()
+    .mapErr(
+      proc() =
+        discard
+    )
+    .get() == oOk.get()
 
   doAssert oErr
-  .mapErr(
-    proc(): int =
-      10
-  )
-  .error() == 10
+    .mapErr(
+      proc(): int =
+        10
+    )
+    .error() == 10
 
   # string conversion
   doAssert $oOk == "ok(42)"
@@ -550,11 +550,11 @@ block: # Result[T, void] aka `Opt`
       Result[void, void].ok()
   ) == oOk
   doAssert oOk
-  .filter(
-    proc(x: int): auto =
-      Result[void, void].err()
-  )
-  .isErr()
+    .filter(
+      proc(x: int): auto =
+        Result[void, void].err()
+    )
+    .isErr()
   doAssert oErr.filter(
     proc(x: int): auto =
       Result[void, void].err()
@@ -565,11 +565,11 @@ block: # Result[T, void] aka `Opt`
       true
   ) == oOk
   doAssert oOk
-  .filter(
-    proc(x: int): bool =
-      false
-  )
-  .isErr()
+    .filter(
+      proc(x: int): bool =
+        false
+    )
+    .isErr()
   doAssert oErr.filter(
     proc(x: int): bool =
       true


### PR DESCRIPTION
https://nim-lang.github.io/Nim/manual.html#overload-resolution-lazy-type-resolution-for-untyped
- using `typed` arguments makes it clear that de facto, types are (mostly) being resolved eagerly due to the presence of overloadds - although in theory the two-argument versions could get away with lazy typing for the second parameter, there seems to be little downside doing it eagerly here.